### PR TITLE
Setting the -source and -target of the Java Compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,19 @@
                 <version>2.17</version>
                 <configuration>
                     <systemProperties>
-                        <property> 
+                        <property>
                             <name>java.util.logging.config.file</name>
                             <value>src/test/resources/test-logging.properties</value>
                         </property>
                     </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fix for compilation errors "Source option 5 is no longer supported. Use 7 or later." and "Target option 5 is no longer supported. Use 7 or later."

---

Command to reproduce errors:
```bash
git clone https://github.com/mongodb-labs/socialite \
     && cd socialite \
     && mvn install -DskipTests
```

---

Output:
```
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 84 source files to /home/andart/tmp/Socialite/socialite/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] Source option 5 is no longer supported. Use 7 or later.
[ERROR] Target option 5 is no longer supported. Use 7 or later.
[INFO] 2 errors.
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  58.924 s
[INFO] Finished at: 2022-11-21T19:20:07+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project socialite: Compilation failure: Compilation failure:
[ERROR] Source option 5 is no longer supported. Use 7 or later.
[ERROR] Target option 5 is no longer supported. Use 7 or later.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

---

System configuration:
```
mvn -version
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: /opt/maven
Java version: 17.0.5, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.0.8-200.fc36.x86_64", arch: "amd64", family: "unix"
```

```
java -version
openjdk version "17.0.5" 2022-10-18
OpenJDK Runtime Environment (Red_Hat-17.0.5.0.8-2.fc36) (build 17.0.5+8)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.5.0.8-2.fc36) (build 17.0.5+8, mixed mode, sharing)
```

```
uname -a
Linux host 6.0.8-200.fc36.x86_64 1 SMP PREEMPT_DYNAMIC Fri Nov 11 15:03:58 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```
