### PR TITLE
Missing JAXB API dependency fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>reflections</artifactId>
             <version>0.9.9-RC1</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Steps to reproduce run-time error:
1. Compile Socialite
2. Attempt to load data

---

Output:
```
Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
    at java.base/java.lang.Class.forName0(Native Method)
    at java.base/java.lang.Class.forName(Class.java:467)
    at org.jboss.logging.Logger.getMessageLogger(Logger.java:2248)
    at org.jboss.logging.Logger.getMessageLogger(Logger.java:2214)
    at org.hibernate.validator.internal.util.logging.LoggerFactory.make(LoggerFactory.java:28)
    at org.hibernate.validator.internal.util.Version.<clinit>(Version.java:27)
    at org.hibernate.validator.internal.engine.ConfigurationImpl.<clinit>(ConfigurationImpl.java:63)
    at org.hibernate.validator.HibernateValidator.createGenericConfiguration(HibernateValidator.java:41)
    at javax.validation.Validation$GenericBootstrapImpl.configure(Validation.java:269)
    at javax.validation.Validation.buildDefaultValidatorFactory(Validation.java:111)
    at com.yammer.dropwizard.validation.Validator.<init>(Validator.java:24)
    at com.yammer.dropwizard.cli.ConfiguredCommand.parseConfiguration(ConfiguredCommand.java:76)
    at com.yammer.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:51)
    at com.yammer.dropwizard.cli.Cli.run(Cli.java:53)
    at com.yammer.dropwizard.Service.run(Service.java:61)
    at com.mongodb.socialite.SocialiteService.main(SocialiteService.java:20)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.JAXBException
    at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
    at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
    ... 16 more
```

---

System configuration:
```
mvn -version
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: /opt/maven
Java version: 17.0.5, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-17-openjdk-17.0.5.0.8-2.fc36.x86_64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.0.8-200.fc36.x86_64", arch: "amd64", family: "unix"
```

```
java -version
openjdk version "17.0.5" 2022-10-18
OpenJDK Runtime Environment (Red_Hat-17.0.5.0.8-2.fc36) (build 17.0.5+8)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.5.0.8-2.fc36) (build 17.0.5+8, mixed mode, sharing)
```

```
uname -a
Linux host 6.0.8-200.fc36.x86_64 1 SMP PREEMPT_DYNAMIC Fri Nov 11 15:03:58 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```
