### PR TITLE
mongodb-driver updated from 3.8.1 to 3.12.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver</artifactId>
-            <version>3.8.1</version>
+            <version>3.12.11</version>
         </dependency>
         <dependency>
             <groupId>com.yammer.dropwizard</groupId>


### PR DESCRIPTION
Based on performance assumptions, the mongodb-driver should be updated from version 3.8.1 to version 3.12.11. The aggregated performance gain equals to 9.62%.

Test's Methodology: 10 cold runs with mongodb-driver v3.8.1, 10 cold runs with mongodb-driver v3.12.11

Test's Setup:
client host: 4 vcpus, 16 Gb RAM, Ubuntu 20.04.1 x86_64
client command to load:
```bash
java -jar "./target/socialite-0.0.1-SNAPSHOT.jar" load --users "100000" --maxfollows "200" --messages "100" --threads "64" config.yml
```
client command to run:
```bash
java -jar "./target/socialite-0.0.1-SNAPSHOT.jar" benchmark --total_users "500" --active_users "200" --concurrency "64" --session_duration "10" --target_rate "2000" --follow_pct "2" --unfollow_pct "1" --read_timeline_pct "50" --scroll_timeline_pct "41" --send_content_pct "4" --fof_agg_pct "1" --fof_query_pct "1" --duration "120" config.yml
```

server host: 4 vcpus, 16 Gb RAM, Ubuntu 20.04.1 x86_64
server MongoDB: v6.0.2, 1-noded ReplicaSet

Test's Results:

| mean rate, calls/second  | avg performance gain, % ((sum of v3.12.11 results / sum of v3.8.1 results)*100 - 100) |
| ------------- | ------------- |
| follow | 11.97 |
| friends_of_friends_agg | 7.01 |
| friends_of_friends_query | 7.05 |
| get_follower_count | 10.01 |
| get_followers | 10.01 |
| read_timeline | 9.73 |
| scroll_timeline | 10.01 |
| send_content | 10.79 |
| unfollow | 10.01 |
